### PR TITLE
SearchBox: clear focus on repeated characters (e.g. movement)

### DIFF
--- a/ItemViewCommon/Search.lua
+++ b/ItemViewCommon/Search.lua
@@ -76,6 +76,9 @@ function BaganatorSearchWidgetMixin:OnLoad()
       self.SearchBox.Instructions:SetText(addonTable.Utilities.GetRandomSearchesText())
     end
   end)
+  self.SearchBox:HookScript("OnChar", function(_, key)
+      BagSearch_OnChar(self.SearchBox)
+  end)
   self.SearchBox:HookScript("OnKeyDown", function(_, key)
     if key == "LALT" or key == "RALT" or key == "ALT" then
       addonTable.CallbackRegistry:TriggerEvent("PropagateAlt")


### PR DESCRIPTION
Hey,
I've added the default `BagSearch_OnChar` function onto your searchbox mixin so it behaves more similar to the default bag searchbox. This function clears the input focus if you input repeated characters, e.g. when moving around so you wont get stuck in the editbox.

I think the function exists in every WoW version, but you might want to make it custom, e.g. just copy the code below, which I'm doing currently for my own addon. 

From blizzard:
`UIPanelTemplates.lua`
```
function BagSearch_OnChar(self, text)
	-- clear focus if the player is repeating keys (ie - trying to move)
	-- TODO: move into base editbox code?
	local MIN_REPEAT_CHARACTERS = 4;
	local searchString = self:GetText();
	if (string.len(searchString) >= MIN_REPEAT_CHARACTERS) then
		local repeatChar = true;
		for i=1, MIN_REPEAT_CHARACTERS - 1, 1 do
			if ( string.sub(searchString,(0-i), (0-i)) ~= string.sub(searchString,(-1-i),(-1-i)) ) then
				repeatChar = false;
				break;
			end
		end
		if ( repeatChar ) then
			self:ClearFocus();
		end
	end
end
```