### PR TITLE
quick-button-identical-slots

### DIFF
--- a/ItemViewCommon/BackpackView.lua
+++ b/ItemViewCommon/BackpackView.lua
@@ -174,6 +174,10 @@ function BaganatorItemViewCommonBackpackViewMixin:ToggleBagSlots()
   addonTable.Config.Set(addonTable.Config.Options.MAIN_VIEW_SHOW_BAG_SLOTS, not addonTable.Config.Get(addonTable.Config.Options.MAIN_VIEW_SHOW_BAG_SLOTS))
 end
 
+function BaganatorItemViewCommonBackpackViewMixin:ToggleIdenticalSlots()
+  addonTable.Config.Set(addonTable.Config.Options.CATEGORY_ITEM_GROUPING, not addonTable.Config.Get(addonTable.Config.Options.CATEGORY_ITEM_GROUPING))
+end
+
 function BaganatorItemViewCommonBackpackViewMixin:UpdateForCharacter(character, isLive)
   addonTable.ReportEntry()
 

--- a/ItemViewCommon/BackpackView.xml
+++ b/ItemViewCommon/BackpackView.xml
@@ -59,6 +59,13 @@
           </OnClick>
         </Scripts>
       </Button>
+      <Button parentKey="ToggleIdenticalSlotsButton" inherits="BaganatorToggleIdenticalSlotsButtonTemplate" frameLevel="700" parentArray="TopButtons">
+        <Scripts>
+          <OnClick>
+            self:GetParent():ToggleIdenticalSlots()
+          </OnClick>
+        </Scripts>
+      </Button>
       <Button parentKey="CurrencyButton" inherits="BaganatorCurrencyButtonTemplate" frameLevel="700"/>
 
       <Frame parentKey="SearchWidget" inherits="BaganatorSearchWidgetTemplate"/>

--- a/ItemViewCommon/Components.xml
+++ b/ItemViewCommon/Components.xml
@@ -222,6 +222,27 @@
     </Scripts>
   </Button>
 
+  <Button name="BaganatorToggleIdenticalSlotsButtonTemplate" inherits="BaganatorTooltipIconButtonTemplate" virtual="true">
+    <KeyValues>
+      <KeyValue key="tooltipHeader" value="BAGANATOR_L_GROUP_IDENTICAL_ITEMS" type="global"/>
+    </KeyValues>
+    <Scripts>
+      <OnLoad>
+        Baganator.Skins.AddFrame("IconButton", self, {"identicalSlots"})
+      </OnLoad>
+    </Scripts>
+    <Layers>
+      <Layer level="ARTWORK">
+        <Texture parentKey="Icon" file="Interface\AddOns\Baganator\Assets\Transfer.png">
+          <Size x="16" y="16"/>
+          <Anchors>
+            <Anchor point="CENTER"/>
+          </Anchors>
+        </Texture>
+      </Layer>
+    </Layers> 
+  </Button>
+
   <Button name="BaganatorBankButtonTemplate" inherits="BaganatorTooltipIconButtonTemplate" virtual="true">
     <KeyValues>
       <KeyValue key="tooltipHeader" value="BAGANATOR_L_BANK" type="global"/>


### PR DESCRIPTION
A quick button for Group Identical Slots Settings

in TBC when you have mage table you need to delete stacks that are not full to get all 80 food from the mage table
if i have group identical slots enabled i can only remove stacks that are full till i have the not full stack with dragging out

so going into settings everytime is a pain :P

maybe the icon is not the best for the button i added