### PR TITLE
[CanIMogIt] Pass item location data to CIMI to calculate bind type

### DIFF
--- a/API/ItemButton.lua
+++ b/API/ItemButton.lua
@@ -336,9 +336,9 @@ addonTable.Utilities.OnAddonLoaded("CanIMogIt", function()
           return
       end
 
-      CIMI_SetIcon(self, CIMI_Update, CanIMogIt:GetTooltipText(details.itemLink, details.itemLocation.bagID, details.itemLocation.slotIndex))
+      CIMI_SetIcon(self, CIMI_Update, CanIMogIt:GetTooltipText(details.itemLink, details.itemLocation and details.itemLocation.bagID, details.itemLocation and details.itemLocation.slotIndex))
     end
-    CIMI_SetIcon(CIMIOverlay, CIMI_Update, CanIMogIt:GetTooltipText(details.itemLink, details.itemLocation.bagID, details.itemLocation.slotIndex))
+    CIMI_SetIcon(CIMIOverlay, CIMI_Update, CanIMogIt:GetTooltipText(details.itemLink, details.itemLocation and details.itemLocation.bagID, details.itemLocation and details.itemLocation.slotIndex))
     return (IsEquipment(details.itemLink) or (C_ToyBox ~= nil and C_ToyBox.GetToyInfo(details.itemID) ~= nil) or IsPet(details.itemID) or (C_MountJournal ~= nil and C_MountJournal.GetMountFromItem(details.itemID) ~= nil))
   end,
   function(itemButton)


### PR DESCRIPTION
Heya, I'm a fairly recent contributor to the CanIMogIt team. I've noticed that Baganator doesn't pass all the data needed for CIMI to calculate an item's bind state. Having accurate bind state for icons helps making quick vendor/mail decisions without having to hover over individual items, at least that's how I use it.

This PR makes it so icons show reliable bind states. When bag and slot info are given, CIMI relies on `C_Container.GetContainerItemLink` to retrieve specific item info, falling back on a given item link when container info is missing.

At first glance this works fine, but I probably don't know all the edge cases.

### Before/after (Retail)
This is the same crafted item with 3 different bind states.
<img width="211" height="78" alt="image" src="https://github.com/user-attachments/assets/b1d54a43-4b0e-45d0-9750-81f1c2b2060e" />
<img width="204" height="78" alt="image" src="https://github.com/user-attachments/assets/9149239d-cfc4-4d43-8c59-db18fa27b889" />

### Code changes
- Pass bag and slot data (from `details.itemLocation`) to `CanIMogIt:GetTooltipText` when `itemLocation` data is available