### PR TITLE
CIMI: update icons when decor is learned

### DIFF
--- a/API/ItemButton.lua
+++ b/API/ItemButton.lua
@@ -365,6 +365,9 @@ addonTable.Utilities.OnAddonLoaded("CanIMogIt", function()
   if C_EventUtils.IsEventValid("PET_JOURNAL_PET_DELETED") then
     RefreshFrame:RegisterEvent("PET_JOURNAL_PET_DELETED")
   end
+  if C_EventUtils.IsEventValid("HOUSE_DECOR_ADDED_TO_CHEST") then
+    RefreshFrame:RegisterEvent("HOUSE_DECOR_ADDED_TO_CHEST")
+  end
   RefreshFrame:SetScript("OnEvent", function()
     Callback()
   end)


### PR DESCRIPTION
When CIMI is enabled, its decor icons need to update properly.

### Changes
- Listen to `HOUSE_DECOR_ADDED_TO_CHEST` event when CIMI is enabled
  - Check if event is valid (compat for Classic)