### PR TITLE
Always show warband gold

### DIFF
--- a/Core/Config.lua
+++ b/Core/Config.lua
@@ -32,6 +32,7 @@ local settings = {
   CURRENCY_HEADERS_COLLAPSED = {key = "currency_headers_collapsed", default = {}},
   CURRENCIES_TRACKED = {key = "currencies_tracked", default = {}},
   CURRENCIES_TRACKED_IMPORTED = {key = "currencies_tracked_imported", default = 0},
+  INCLUDE_WARBAND_GOLD_IN_REALM_TOTAL = {key = "include_warband_gold_in_realm_total", default = false},
   SHOW_SEARCH_BOX = {key = "show_search_box", default = true, refresh = {Refresh.Layout}},
 
   BANK_CURRENT_TAB = {key = "bank_current_tab", default = 1},

--- a/CustomiseDialog/Main.lua
+++ b/CustomiseDialog/Main.lua
@@ -113,6 +113,11 @@ local LAYOUT_OPTIONS = {
   },
   {
     type = "checkbox",
+    text = addonTable.Locales.INCLUDE_WARBAND_GOLD_IN_REALM_TOTAL,
+    option = "include_warband_gold_in_realm_total",
+  },
+  {
+    type = "checkbox",
     text = addonTable.Locales.REDUCE_UI_SPACING,
     option = "reduce_spacing",
   },

--- a/ItemViewCommon/CurrencyBar.lua
+++ b/ItemViewCommon/CurrencyBar.lua
@@ -53,7 +53,11 @@ function BaganatorCurrencyWidgetMixin:OnLoad()
     if IsShiftKeyDown() then
       addonTable.ShowGoldSummaryAccount(self.Money, "ANCHOR_TOP")
     else
-      addonTable.ShowGoldSummaryRealm(self.Money, "ANCHOR_TOP")
+      addonTable.ShowGoldSummaryRealm(
+        self.Money,
+        "ANCHOR_TOP",
+        addonTable.Config.Get(addonTable.Config.Options.INCLUDE_WARBAND_GOLD_IN_REALM_TOTAL)
+      )
     end
   end
   self.Money:SetScript("OnEnter", function()

--- a/ItemViewCommon/MoneyDisplay.lua
+++ b/ItemViewCommon/MoneyDisplay.lua
@@ -9,7 +9,7 @@ local function GetShowState(data)
   end
 end
 
-function addonTable.ShowGoldSummaryRealm(anchor, point)
+function addonTable.ShowGoldSummaryRealm(anchor, point, includeWarband)
   GameTooltip:SetOwner(anchor, point)
 
   local connectedRealms = Syndicator.Utilities.GetConnectedRealms()
@@ -41,6 +41,19 @@ function addonTable.ShowGoldSummaryRealm(anchor, point)
 
   local lines = {}
   local total = 0
+
+  if includeWarband then
+    local warbandData = Syndicator.API.GetWarband and Syndicator.API.GetWarband(1)
+    if warbandData and (warbandData.details == nil or warbandData.details.gold) then
+      local warband = warbandData.money or 0
+      if warband > 0 then
+        table.insert(lines, {left = PASSIVE_SPELL_FONT_COLOR:WrapTextInColorCode(addonTable.Locales.WARBAND), right = addonTable.Utilities.GetMoneyString(warband, true)})
+        table.insert(lines, {left = " ", right = ""})
+      end
+      total = total + warband
+    end
+  end
+
   for _, characterInfo in ipairs(allCharacters) do
     if realmsToInclude[characterInfo.realmNormalized] and GetShowState(Syndicator.API.GetCharacter(characterInfo.fullName)) and (not applyFaction or currentFaction == characterInfo.faction) then
       local money = Syndicator.API.GetCharacter(characterInfo.fullName).money

--- a/ItemViewCommon/MoneyDisplay.lua
+++ b/ItemViewCommon/MoneyDisplay.lua
@@ -9,6 +9,21 @@ local function GetShowState(data)
   end
 end
 
+local function AddWarbandLine(lines, warband)
+  if warband > 0 then
+    table.insert(lines, {left = PASSIVE_SPELL_FONT_COLOR:WrapTextInColorCode(addonTable.Locales.WARBAND), right = addonTable.Utilities.GetMoneyString(warband, true)})
+    table.insert(lines, {left = " ", right = ""})
+  end
+end
+
+local function GetWarbandGold()
+  local warbandData = Syndicator.API.GetWarband and Syndicator.API.GetWarband(1)
+  if warbandData and (warbandData.details == nil or warbandData.details.gold) then
+    return warbandData.money or 0
+  end
+  return 0
+end
+
 function addonTable.ShowGoldSummaryRealm(anchor, point, includeWarband)
   GameTooltip:SetOwner(anchor, point)
 
@@ -43,15 +58,9 @@ function addonTable.ShowGoldSummaryRealm(anchor, point, includeWarband)
   local total = 0
 
   if includeWarband then
-    local warbandData = Syndicator.API.GetWarband and Syndicator.API.GetWarband(1)
-    if warbandData and (warbandData.details == nil or warbandData.details.gold) then
-      local warband = warbandData.money or 0
-      if warband > 0 then
-        table.insert(lines, {left = PASSIVE_SPELL_FONT_COLOR:WrapTextInColorCode(addonTable.Locales.WARBAND), right = addonTable.Utilities.GetMoneyString(warband, true)})
-        table.insert(lines, {left = " ", right = ""})
-      end
-      total = total + warband
-    end
+    local warband = GetWarbandGold()
+    AddWarbandLine(lines, warband)
+    total = total + warband
   end
 
   for _, characterInfo in ipairs(allCharacters) do
@@ -111,21 +120,11 @@ function addonTable.ShowGoldSummaryAccount(anchor, point)
   local function AddGuild(guildName, guildRealmNormalized, guildTotal)
     table.insert(lines, {left = TRANSMOGRIFY_FONT_COLOR:WrapTextInColorCode(guildName) .. "-" .. guildRealmNormalized, right = addonTable.Utilities.GetMoneyString(guildTotal, true)})
   end
-  local function AddWarband(warband)
-    if warband > 0 then
-      table.insert(lines, {left = PASSIVE_SPELL_FONT_COLOR:WrapTextInColorCode(addonTable.Locales.WARBAND), right = addonTable.Utilities.GetMoneyString(warband, true)})
-      table.insert(lines, {left = " ", right = ""})
-    end
-  end
-
   local total = 0
 
-  local warbandData = Syndicator.API.GetWarband and Syndicator.API.GetWarband(1)
-  if warbandData and (warbandData.details == nil or warbandData.details.gold) then
-    local warband = warbandData.money or 0
-    AddWarband(warband)
-    total = total + warband
-  end
+  local warband = GetWarbandGold()
+  AddWarbandLine(lines, warband)
+  total = total + warband
 
   local realmTotal = 0
   local realmCount = 0

--- a/Locales.lua
+++ b/Locales.lua
@@ -173,6 +173,7 @@ L["FACTION_REALM_WIDE_GOLD_X"] = "Faction/realm-wide gold: %s"
 L["ACCOUNT_GOLD_X"] = "Account gold: %s"
 L["REALM_X_X_X"] = "%s (x%s)"
 L["HOLD_SHIFT_TO_SHOW_ACCOUNT_TOTAL"] = "<Hold shift to show account total>"
+L["INCLUDE_WARBAND_GOLD_IN_REALM_TOTAL"] = "Include Warband Gold in Realm Total"
 
 L["CRAFTING_WINDOW"] = "Crafting Window"
 L["AUCTION_HOUSE"] = "Auction House"


### PR DESCRIPTION
I wanted to be able to see my total warband gold by default in the gold tooltip without pressing shift. This change adds the option and defaults to the old behavior.

Implements #207 

AI Disclosure: I used Cursor's tools to help create this change, but I reviewed the code did some refactoring to extract the `AddWarbandLine`.

| Screenshots |
|--------|
| **Disabled (default)** |
| <img width="1038" height="264" alt="Screenshot 2026-03-25 at 11 21 38 AM" src="https://github.com/user-attachments/assets/f501cf87-a788-45b3-bcfb-65ffc2ff93f6" /> |
| **Enabled** |
| <img width="1028" height="291" alt="Screenshot 2026-03-25 at 11 21 27 AM" src="https://github.com/user-attachments/assets/456701d8-4a70-4f28-becd-9e3e1480540e" /> | 
