### PR TITLE
Slash command search can include spaces

### DIFF
--- a/Core/SlashCmd.lua
+++ b/Core/SlashCmd.lua
@@ -101,7 +101,11 @@ end
 function addonTable.SlashCmd.Search(...)
   local text = ""
   for i,v in ipairs({...}) do
-    text = text .. " " .. v
+    if i > 1 then
+      text = text .. " " .. v
+    else
+      text = t
+    end
   end
   addonTable.CallbackRegistry:TriggerEvent("SearchTextChanged", text)
   addonTable.CallbackRegistry:TriggerEvent("BagShow")

--- a/Core/SlashCmd.lua
+++ b/Core/SlashCmd.lua
@@ -99,15 +99,7 @@ function addonTable.SlashCmd.RemoveUnusedCategories()
 end
 
 function addonTable.SlashCmd.Search(...)
-  local text = ""
-  for i,v in ipairs({...}) do
-    if i > 1 then
-      text = text .. " " .. v
-    else
-      text = t
-    end
-  end
-  addonTable.CallbackRegistry:TriggerEvent("SearchTextChanged", text)
+  addonTable.CallbackRegistry:TriggerEvent("SearchTextChanged", table.concat({ ... }, " "))
   addonTable.CallbackRegistry:TriggerEvent("BagShow")
 end
 

--- a/Core/SlashCmd.lua
+++ b/Core/SlashCmd.lua
@@ -98,7 +98,11 @@ function addonTable.SlashCmd.RemoveUnusedCategories()
   addonTable.Utilities.Message(addonTable.Locales.REMOVED_UNUSED_CATEGORIES)
 end
 
-function addonTable.SlashCmd.Search(text)
+function addonTable.SlashCmd.Search(...)
+  local text = ""
+  for i,v in ipairs({...}) do
+    text = text .. " " .. v
+  end
   addonTable.CallbackRegistry:TriggerEvent("SearchTextChanged", text)
   addonTable.CallbackRegistry:TriggerEvent("BagShow")
 end


### PR DESCRIPTION
### Current behaviour
`/bgr search trade goods` opens the bag with a search of "trade"

### Updated behaviour
`/bgr search trade goods` opens the bag with a search of "trade goods"


### Explanation
Since the slash command handler uses
```lua
COMMANDS[root](unpack(split))
```
each word gets sent as a separate argument to `addonTable.ShashCmd.Search`, but the function definition is such that it only accepts a single argument.

Updated `addonTable.ShashCmd.Search` definition to accept a variable number of arguments